### PR TITLE
fix: add background on hover  in EditLabel component

### DIFF
--- a/components/LocalKv.tsx
+++ b/components/LocalKv.tsx
@@ -30,7 +30,7 @@ export function LocalKv({ db: { name, id, size } }: { db: KvLocalInfo }) {
       <div class="flex-grow-0 overflow-hidden px-2">
         <EditLabel
           value={value}
-          labelClass="block cursor-text w-full"
+          labelClass="block cursor-text w-full hover:bg-gray(300 dark:700) rounded"
           inputClass="bg-gray-50 border border-gray-300 text-gray-900 rounded focus:ring-blue-500 focus:border-blue-500 px-2 block w-full dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
           emptyDisplay="[unnamed]"
         />


### PR DESCRIPTION
<img width="785" alt="image" src="https://github.com/kitsonk/kview/assets/3132889/5ee63f53-3cf6-43e4-adeb-c66d01019cb4">

To make it clear that labels can be edited, we've added a style for when they are hovered over.