### PR TITLE
fix: change typing and attribute handling for organization details.

### DIFF
--- a/routes/orgs/[id].tsx
+++ b/routes/orgs/[id].tsx
@@ -8,11 +8,10 @@ export default async function OrganizationDetails(
   _req: Request,
   { params: { id } }: RouteContext,
 ) {
-  let { projects, name } = await getOrganizationDetail(id);
-  const isUser = name === null;
-  if (!isUser) {
-    name = (await getRootData()).user.name;
-  }
+  const { organization } = await getOrganizationDetail(id);
+  const projects = organization.projects ?? [];
+  const name = organization.name ?? (await getRootData()).user.name;
+  const isUser = organization.name === null;
 
   return (
     <AppFrame

--- a/utils/dash.ts
+++ b/utils/dash.ts
@@ -226,7 +226,7 @@ export async function getProjectDetails(name: string): Promise<DashProject> {
 /** For a given organization, retrieve the organization details. */
 export async function getOrganizationDetail(
   id: string,
-): Promise<DashOrganizationDetail> {
+): Promise<{ organization: DashOrganizationDetail }> {
   const req = await fetch(`${DASH_BASE_URL}orgs/${id}?_data_`, {
     method: "GET",
     headers: {


### PR DESCRIPTION
There's a bug in the orgs route where the `projects` attribute is undefined (see attached screenshot). The problem stems from a typing error in `utils/dash.ts` where the result from the API call is nested in an `organization` attribute (which in turn contains what the route is asking for). I've updated the type for the return value in `utils/dash.ts` and corrected the attribute handling in the route.


![Screenshot 2024-02-12 at 00 54 20](https://github.com/kitsonk/kview/assets/303580/80afef73-5abf-4fc9-96eb-25d0f30bd288)
